### PR TITLE
feat: ECOS-2 API Keys & Public v1 Endpoint

### DIFF
--- a/app/api/keys/route.js
+++ b/app/api/keys/route.js
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { createApiKey, listApiKeys, revokeApiKey } from "@/lib/api-keys";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// GET: List the authenticated user's API keys
+export async function GET() {
+  const { userId } = await auth();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  try {
+    const keys = await listApiKeys(userId);
+    return NextResponse.json({ keys });
+  } catch (e) {
+    return NextResponse.json({ error: e.message }, { status: 500 });
+  }
+}
+
+// POST: Create a new API key
+export async function POST(request) {
+  const { userId } = await auth();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { label } = await request.json().catch(() => ({}));
+
+  try {
+    const key = await createApiKey(userId, label || "Default");
+    return NextResponse.json(key);
+  } catch (e) {
+    return NextResponse.json({ error: e.message }, { status: 400 });
+  }
+}
+
+// DELETE: Revoke an API key
+export async function DELETE(request) {
+  const { userId } = await auth();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { searchParams } = new URL(request.url);
+  const keyId = searchParams.get("id");
+  if (!keyId) return NextResponse.json({ error: "Missing key id" }, { status: 400 });
+
+  try {
+    await revokeApiKey(userId, keyId);
+    return NextResponse.json({ success: true });
+  } catch (e) {
+    return NextResponse.json({ error: e.message }, { status: 400 });
+  }
+}

--- a/app/api/v1/run/route.js
+++ b/app/api/v1/run/route.js
@@ -1,0 +1,89 @@
+import { NextResponse } from "next/server";
+import { validateApiKey } from "@/lib/api-keys";
+import { deductCredits } from "@/lib/storage";
+import { runAgenticTask } from "@/lib/orchestrator";
+import { saveRun } from "@/lib/storage";
+import { getCachedRun, setCachedRun } from "@/lib/cache";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function buildRunWithRuntime(run, extra = {}) {
+  return { ...run, runtime: extra };
+}
+
+/**
+ * POST /api/v1/run
+ * 
+ * Public API endpoint for programmatic access via API keys.
+ * 
+ * Headers:
+ *   Authorization: Bearer gt_live_<key>
+ * 
+ * Body:
+ *   { "task": "string", "providerMode": "auto|speed|power", "objective": "golden" }
+ * 
+ * Returns the full agentic run result.
+ */
+export async function POST(request) {
+  // Extract API key from Authorization header
+  const authHeader = request.headers.get("authorization") || "";
+  const token = authHeader.replace(/^Bearer\s+/i, "").trim();
+
+  if (!token || !token.startsWith("gt_live_")) {
+    return NextResponse.json({
+      error: "Missing or invalid API key. Provide a valid key in the Authorization header: Bearer gt_live_<key>"
+    }, { status: 401 });
+  }
+
+  // Validate key
+  const keyData = await validateApiKey(token);
+  if (!keyData) {
+    return NextResponse.json({ error: "Invalid or revoked API key." }, { status: 401 });
+  }
+
+  const userId = keyData.userId;
+
+  // Parse body
+  const body = await request.json().catch(() => ({}));
+  const task = typeof body.task === "string" ? body.task.trim() : "";
+  const providerMode = typeof body.providerMode === "string" ? body.providerMode : "auto";
+  const objective = typeof body.objective === "string" ? body.objective : "golden";
+
+  if (!task) {
+    return NextResponse.json({ error: "task is required." }, { status: 400 });
+  }
+
+  try {
+    // Check cache first (free)
+    const cacheLookup = await getCachedRun({ task, providerMode, objective }, { bypass: false });
+
+    if (cacheLookup.hit && cacheLookup.run) {
+      return NextResponse.json({
+        run: buildRunWithRuntime(cacheLookup.run, { responseSource: "cache" }),
+        cache: { status: "hit", key: cacheLookup.key }
+      });
+    }
+
+    // Deduct credits for live run
+    try {
+      await deductCredits(userId, 1);
+    } catch (e) {
+      return NextResponse.json({
+        error: e.message || "Insufficient compute credits. Top up at /dashboard/billing."
+      }, { status: 402 });
+    }
+
+    // Execute
+    const liveRun = await runAgenticTask({ task, providerMode, objective });
+    const run = buildRunWithRuntime(liveRun, { responseSource: "live" });
+
+    // Persist
+    await saveRun(liveRun).catch(() => {});
+    await setCachedRun({ task, providerMode, objective }, liveRun).catch(() => {});
+
+    return NextResponse.json({ run, cache: { status: "miss" } });
+  } catch (e) {
+    return NextResponse.json({ error: e.message || "Execution failed" }, { status: 500 });
+  }
+}

--- a/app/dashboard/keys/page.jsx
+++ b/app/dashboard/keys/page.jsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+function KeyRow({ apiKey, onRevoke }) {
+  const isRevoked = apiKey.revoked;
+
+  return (
+    <div style={{
+      display: "flex", alignItems: "center", justifyContent: "space-between",
+      padding: "14px 0", borderTop: "1px solid var(--line)",
+      opacity: isRevoked ? 0.45 : 1
+    }}>
+      <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: "10px" }}>
+          <span style={{ fontWeight: 600, fontSize: "0.9rem" }}>{apiKey.label}</span>
+          {isRevoked && (
+            <span style={{ fontSize: "0.68rem", padding: "2px 8px", borderRadius: "999px", background: "rgba(159,45,28,0.08)", color: "var(--danger)", border: "1px solid rgba(159,45,28,0.15)" }}>
+              REVOKED
+            </span>
+          )}
+        </div>
+        <span style={{ fontFamily: "var(--font-mono), monospace", fontSize: "0.78rem", color: "var(--ink-soft)" }}>
+          {apiKey.keyPrefix}
+        </span>
+        <div style={{ display: "flex", gap: "14px", fontSize: "0.72rem", color: "var(--ink-soft)" }}>
+          <span>Created {new Date(apiKey.createdAt).toLocaleDateString()}</span>
+          {apiKey.lastUsedAt && <span>Last used {new Date(apiKey.lastUsedAt).toLocaleDateString()}</span>}
+        </div>
+      </div>
+      {!isRevoked && (
+        <button
+          onClick={() => onRevoke(apiKey.id)}
+          style={{
+            background: "none", border: "1px solid rgba(159,45,28,0.2)", borderRadius: "10px",
+            padding: "6px 14px", cursor: "pointer", fontSize: "0.78rem", color: "var(--danger)",
+            transition: "all 150ms"
+          }}
+          onMouseEnter={e => { e.currentTarget.style.background = "rgba(159,45,28,0.06)"; }}
+          onMouseLeave={e => { e.currentTarget.style.background = "none"; }}
+        >
+          Revoke
+        </button>
+      )}
+    </div>
+  );
+}
+
+export default function ApiKeysPage() {
+  const [keys, setKeys] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [newLabel, setNewLabel] = useState("");
+  const [creating, setCreating] = useState(false);
+  const [newKey, setNewKey] = useState(null);
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState("");
+
+  const fetchKeys = () => {
+    setLoading(true);
+    fetch("/api/keys")
+      .then(r => r.json())
+      .then(d => setKeys(d.keys || []))
+      .catch(e => setError(e.message))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => { fetchKeys(); }, []);
+
+  const handleCreate = async () => {
+    setCreating(true);
+    setError("");
+    try {
+      const res = await fetch("/api/keys", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ label: newLabel || "Default" })
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error);
+      setNewKey(data);
+      setNewLabel("");
+      fetchKeys();
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleRevoke = async (keyId) => {
+    try {
+      const res = await fetch(`/api/keys?id=${keyId}`, { method: "DELETE" });
+      if (!res.ok) throw new Error("Revoke failed");
+      fetchKeys();
+    } catch (e) {
+      setError(e.message);
+    }
+  };
+
+  const handleCopy = () => {
+    if (newKey?.rawKey) {
+      navigator.clipboard.writeText(newKey.rawKey);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  const activeKeys = keys.filter(k => !k.revoked);
+
+  return (
+    <div style={{ maxWidth: "760px", margin: "0 auto", padding: "2rem" }}>
+      <header style={{ marginBottom: "28px" }}>
+        <h1 style={{ margin: 0, fontSize: "1.5rem" }}>API Keys</h1>
+        <p className="muted" style={{ marginTop: "6px" }}>
+          Generate keys for programmatic access to the Golden Triad agent via <code style={{ background: "rgba(0,0,0,0.05)", padding: "2px 6px", borderRadius: "4px", fontSize: "0.82rem" }}>POST /api/v1/run</code>
+        </p>
+      </header>
+
+      {error && (
+        <div className="error-box" style={{ marginBottom: "16px" }}>{error}</div>
+      )}
+
+      {/* New Key Alert */}
+      {newKey && (
+        <div className="surface" style={{
+          padding: "20px", borderRadius: "18px", marginBottom: "20px",
+          border: "2px solid var(--accent)", animation: "fade-up 300ms ease"
+        }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
+            <div>
+              <strong style={{ color: "var(--accent)" }}>Key Created — Copy It Now</strong>
+              <p className="muted" style={{ fontSize: "0.82rem", margin: "6px 0 0" }}>
+                This is the only time your full key will be shown. Store it securely.
+              </p>
+            </div>
+            <button onClick={() => setNewKey(null)} style={{ background: "none", border: "none", cursor: "pointer", fontSize: "1.1rem", color: "var(--ink-soft)" }}>✕</button>
+          </div>
+          <div style={{
+            marginTop: "14px", display: "flex", gap: "10px", alignItems: "center"
+          }}>
+            <code style={{
+              flex: 1, padding: "12px 14px", borderRadius: "12px",
+              background: "rgba(0,0,0,0.04)", border: "1px solid var(--line)",
+              fontFamily: "var(--font-mono), monospace", fontSize: "0.82rem",
+              wordBreak: "break-all"
+            }}>
+              {newKey.rawKey}
+            </code>
+            <button
+              onClick={handleCopy}
+              className="primary-action"
+              style={{ padding: "10px 18px", fontSize: "0.82rem", whiteSpace: "nowrap" }}
+            >
+              {copied ? "Copied ✓" : "Copy"}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Create Key */}
+      <div className="surface" style={{ padding: "20px", borderRadius: "20px", marginBottom: "24px" }}>
+        <span className="section-title">Create New Key</span>
+        <div style={{ display: "flex", gap: "10px", marginTop: "14px", alignItems: "end" }}>
+          <div className="field" style={{ flex: 1 }}>
+            <label className="label">Label</label>
+            <input
+              type="text"
+              value={newLabel}
+              onChange={e => setNewLabel(e.target.value)}
+              placeholder="e.g. Production, CI/CD Pipeline"
+              style={{
+                width: "100%", padding: "10px 14px", borderRadius: "14px",
+                border: "1px solid var(--line)", background: "var(--panel-strong)",
+                color: "var(--ink)", fontSize: "0.88rem"
+              }}
+            />
+          </div>
+          <button
+            onClick={handleCreate}
+            disabled={creating}
+            className="primary-action"
+            style={{ padding: "10px 20px", fontSize: "0.85rem" }}
+          >
+            {creating ? "Creating…" : "Generate Key"}
+          </button>
+        </div>
+        <p className="muted" style={{ marginTop: "10px", fontSize: "0.78rem" }}>
+          {activeKeys.length}/5 active keys used
+        </p>
+      </div>
+
+      {/* Usage Example */}
+      <div className="surface" style={{ padding: "20px", borderRadius: "20px", marginBottom: "24px" }}>
+        <span className="section-title">Quick Start</span>
+        <pre style={{
+          marginTop: "14px", padding: "16px", borderRadius: "14px",
+          background: "rgba(0,0,0,0.04)", border: "1px solid var(--line)",
+          overflow: "auto", fontSize: "0.78rem", lineHeight: 1.6,
+          fontFamily: "var(--font-mono), monospace"
+        }}>
+{`curl -X POST https://your-domain.com/api/v1/run \\
+  -H "Authorization: Bearer gt_live_your_key_here" \\
+  -H "Content-Type: application/json" \\
+  -d '{"task": "Analyze this codebase for security issues"}'`}
+        </pre>
+      </div>
+
+      {/* Keys List */}
+      <div className="surface" style={{ padding: "20px", borderRadius: "20px" }}>
+        <span className="section-title">Your Keys</span>
+        <div style={{ marginTop: "10px" }}>
+          {loading && <p className="muted">Loading…</p>}
+          {!loading && keys.length === 0 && (
+            <div className="empty-state" style={{ marginTop: "10px" }}>
+              <p className="muted" style={{ textAlign: "center" }}>No API keys created yet.</p>
+            </div>
+          )}
+          {keys.map(k => (
+            <KeyRow key={k.id} apiKey={k} onRevoke={handleRevoke} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,74 @@
+# API Reference
+
+The Golden Triad Agentic System exposes a public REST API for programmatic access to the agent pipeline.
+
+## Authentication
+
+All API requests require a valid API key passed in the `Authorization` header:
+
+```
+Authorization: Bearer gt_live_<your_key>
+```
+
+API keys can be generated from the dashboard at `/dashboard/keys`. Keys are shown only once at creation — store them securely. Keys can be revoked at any time.
+
+## Endpoints
+
+### `POST /api/v1/run`
+
+Execute an agentic task through the full Architect → Builder → Reviewer pipeline.
+
+**Request Body:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `task` | string | ✅ | The task/prompt to execute |
+| `providerMode` | string | — | `"auto"` (default), `"speed"`, or `"power"` |
+| `objective` | string | — | `"golden"` (default) |
+
+**Example:**
+
+```bash
+curl -X POST https://your-domain.com/api/v1/run \
+  -H "Authorization: Bearer gt_live_abc123def456" \
+  -H "Content-Type: application/json" \
+  -d '{"task": "Write a Python script to parse CSV files"}'
+```
+
+**Response (200):**
+
+```json
+{
+  "run": {
+    "id": "uuid",
+    "task": "...",
+    "finalAnswer": "...",
+    "phases": [...],
+    "runtime": { "responseSource": "live" }
+  },
+  "cache": { "status": "miss" }
+}
+```
+
+**Error Responses:**
+
+| Status | Meaning |
+|---|---|
+| `401` | Missing or invalid API key |
+| `402` | Insufficient compute credits |
+| `400` | Missing required `task` field |
+| `500` | Internal execution error |
+
+## Rate Limits & Credits
+
+- Each live execution costs **1 compute credit**.
+- Cache hits are **free** (no credit deduction).
+- Credits can be purchased at `/dashboard/billing`.
+- The credit balance is the same whether accessed via dashboard or API.
+
+## Key Management
+
+- Maximum **5 active keys** per user.
+- Keys use the format `gt_live_<32 hex characters>`.
+- Keys are hashed with SHA-256 before storage — we never store your raw key.
+- Revoked keys cannot be reactivated.

--- a/lib/api-keys.js
+++ b/lib/api-keys.js
@@ -1,0 +1,163 @@
+/**
+ * lib/api-keys.js
+ * 
+ * API Key management for programmatic access.
+ * Keys are hashed with SHA-256 before storage — raw keys are only shown once at creation.
+ * Format: gt_live_<32 hex chars>
+ */
+
+import crypto from "node:crypto";
+import { getIntegrationConfig } from "@/lib/integrations";
+import postgres from "postgres";
+
+let sqlClient;
+
+function getClient() {
+  const db = getIntegrationConfig("postgres");
+  if (!db.configured) return null;
+  if (!sqlClient) {
+    sqlClient = postgres(db.secretValue, {
+      ssl: process.env.DATABASE_SSL !== "disable" ? "require" : false,
+      max: 2
+    });
+  }
+  return sqlClient;
+}
+
+let schemaReady = false;
+
+async function ensureSchema() {
+  const sql = getClient();
+  if (!sql || schemaReady) return sql;
+
+  await sql`
+    create table if not exists api_keys (
+      id text primary key default gen_random_uuid()::text,
+      clerk_user_id text not null,
+      key_hash text not null unique,
+      key_prefix text not null,
+      label text not null default 'Default',
+      scopes text[] not null default '{"runs"}',
+      created_at timestamptz not null default now(),
+      last_used_at timestamptz,
+      revoked boolean not null default false
+    )
+  `;
+  await sql`
+    create index if not exists idx_api_keys_hash on api_keys (key_hash) where revoked = false
+  `;
+
+  schemaReady = true;
+  return sql;
+}
+
+// ─── Key Generation ──────────────────────────────────────────────────────────
+
+function generateRawKey() {
+  const random = crypto.randomBytes(16).toString("hex"); // 32 chars
+  return `gt_live_${random}`;
+}
+
+function hashKey(rawKey) {
+  return crypto.createHash("sha256").update(rawKey).digest("hex");
+}
+
+// ─── CRUD ────────────────────────────────────────────────────────────────────
+
+export async function createApiKey(clerkUserId, label = "Default") {
+  const sql = await ensureSchema();
+  if (!sql) throw new Error("Database not available");
+
+  // Enforce limit: max 5 active keys per user
+  const [countRow] = await sql`
+    select count(*)::int as count from api_keys
+    where clerk_user_id = ${clerkUserId} and revoked = false
+  `;
+  if (countRow.count >= 5) {
+    throw new Error("Maximum of 5 active API keys reached. Revoke an existing key first.");
+  }
+
+  const rawKey = generateRawKey();
+  const keyHash = hashKey(rawKey);
+  const keyPrefix = rawKey.slice(0, 12) + "…";
+
+  const [row] = await sql`
+    insert into api_keys (clerk_user_id, key_hash, key_prefix, label)
+    values (${clerkUserId}, ${keyHash}, ${keyPrefix}, ${label})
+    returning id, key_prefix, label, scopes, created_at
+  `;
+
+  return {
+    id: row.id,
+    rawKey,           // Only returned once — never stored
+    keyPrefix: row.key_prefix,
+    label: row.label,
+    scopes: row.scopes,
+    createdAt: row.created_at
+  };
+}
+
+export async function listApiKeys(clerkUserId) {
+  const sql = await ensureSchema();
+  if (!sql) return [];
+
+  const rows = await sql`
+    select id, key_prefix, label, scopes, created_at, last_used_at, revoked
+    from api_keys
+    where clerk_user_id = ${clerkUserId}
+    order by created_at desc
+  `;
+
+  return rows.map(r => ({
+    id: r.id,
+    keyPrefix: r.key_prefix,
+    label: r.label,
+    scopes: r.scopes,
+    createdAt: r.created_at,
+    lastUsedAt: r.last_used_at,
+    revoked: r.revoked
+  }));
+}
+
+export async function revokeApiKey(clerkUserId, keyId) {
+  const sql = await ensureSchema();
+  if (!sql) throw new Error("Database not available");
+
+  const [row] = await sql`
+    update api_keys
+    set revoked = true
+    where id = ${keyId} and clerk_user_id = ${clerkUserId}
+    returning id
+  `;
+
+  if (!row) throw new Error("Key not found or already revoked");
+  return true;
+}
+
+// ─── Validation (for incoming API requests) ──────────────────────────────────
+
+export async function validateApiKey(rawKey) {
+  if (!rawKey || !rawKey.startsWith("gt_live_")) return null;
+
+  const sql = await ensureSchema();
+  if (!sql) return null;
+
+  const keyHash = hashKey(rawKey);
+
+  const [row] = await sql`
+    select id, clerk_user_id, scopes
+    from api_keys
+    where key_hash = ${keyHash} and revoked = false
+  `;
+
+  if (!row) return null;
+
+  // Update last_used_at (fire-and-forget)
+  sql`update api_keys set last_used_at = now() where id = ${row.id}`.catch(() => {});
+
+  return {
+    keyId: row.id,
+    userId: row.clerk_user_id,
+    scopes: row.scopes
+  };
+}


### PR DESCRIPTION
Adds programmatic API access via generated API keys.

## New Files
- **lib/api-keys.js** — Key generation (gt_live_ prefix), SHA-256 hashed storage, CRUD, validation
- **app/api/keys/route.js** — Key management (GET/POST/DELETE)
- **app/api/v1/run/route.js** — Public API endpoint authenticated via Bearer token
- **app/dashboard/keys/page.jsx** — Key management UI with one-time reveal, copy, and revoke
- **docs/api-reference.md** — Full API documentation

## How It Works
1. User generates a key at /dashboard/keys
2. Raw key shown once, hashed before storage
3. External systems call POST /api/v1/run with Bearer auth
4. Same credit deduction + caching logic as dashboard runs